### PR TITLE
Allow Child themes of decaf to set their own custommenu Fixes #23

### DIFF
--- a/layout/navbar.inc.php
+++ b/layout/navbar.inc.php
@@ -7,7 +7,12 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$custommenu = $OUTPUT->custom_menu();
+if (isset($PAGE->theme->settings->custommenuitems)) {
+    $custommenu = $OUTPUT->custom_menu($PAGE->theme->settings->custommenuitems);
+} else {
+    $custommenu = $OUTPUT->custom_menu();
+}
+
 $hascustommenu = (empty($PAGE->layout_options['nocustommenu']) && !empty($custommenu));
 ?>
 <header role="banner" class="navbar navbar-fixed-top<?php echo $html->navbarclass ?> moodle-has-zindex">
@@ -43,7 +48,7 @@ $hascustommenu = (empty($PAGE->layout_options['nocustommenu']) && !empty($custom
             </a>
             <div class="nav-collapse collapse">
                 <?php if ($hascustommenu && empty($decaf->custommenuinawesomebar)) {
-                    echo $OUTPUT->custom_menu();
+                    echo $custommenu;
                 } ?>
                 <ul class="nav pull-right">
                     <li><?php echo $OUTPUT->page_heading_menu(); ?></li>


### PR DESCRIPTION
Here's a slight variation on the original suggestion - looks like $custommenu is defined at the top and re-used in multiple ways. I haven't tested this very well yet. Will deploy this to a client's site tomorrow and let you know.
